### PR TITLE
[Bug fix] with &pos.position garbage received in the receiver robot. …

### DIFF
--- a/adhoc_communication/src/adhoc_communication.cpp
+++ b/adhoc_communication/src/adhoc_communication.cpp
@@ -3055,7 +3055,7 @@ void publishPacket(Packet * p)
                         adhoc_communication::MmRobotPosition();
                 //pos.position = getPoseStampFromNetworkString(
                 //		(unsigned char*) payload.data(), payload.length());
-                desializeObject((unsigned char*) payload.data(), payload.length(), &pos.position);
+                desializeObject((unsigned char*) payload.data(), payload.length(), &pos);
                 pos.src_robot = p->hostname_source_;
                 publishMessage(pos, p->topic_);
             }


### PR DESCRIPTION
…Should be only &pos of type MmRobotPosition. As we serialize the message of type MmRobotPosition, the deserialized should also be of type MmRobotPosition, else we get garbage output. 
