### PR TITLE
fix Boost's linkage issues

### DIFF
--- a/adhoc_communication/CMakeLists.txt
+++ b/adhoc_communication/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 ## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
+find_package(Boost REQUIRED COMPONENTS system thread)
 
 
 ## Uncomment this if the package has a setup.py. This macro ensures
@@ -161,6 +161,7 @@ add_dependencies(adhoc_communication adhoc_communication_gencpp)
 ## Specify libraries to link a library or executable target against
  target_link_libraries(adhoc_communication
    ${catkin_LIBRARIES}
+   ${Boost_LIBRARIES}
  )
 
 

--- a/adhoc_communication/src/functions.h
+++ b/adhoc_communication/src/functions.h
@@ -7,6 +7,7 @@
 
 #ifndef FUNCTIONS_H_
 #define FUNCTIONS_H_
+#include <boost/format.hpp>
 
 struct mac {
     unsigned char mac_adr[6];


### PR DESCRIPTION
Hi authors of aau_multi_robot,\
You've a great package having ROS support, cheers!

I came across few build/linkage issues related to Boost library, while building *adhoc_communication* (alone) using catkin_make/catkin. Following is a short gist of it, which I found applies to a system having Ubuntu 14.04, gxx-4.8 or gxx-5, Boost 1.54 or 1.63.

1. Without having `boost/format.hpp` header inclusion in `function.h` header, Boost's format module isn't recognized.
2. Appropriate linkage of the Boost library has to be done in `CMakeLists.txt` of *adhoc_communication*. 

Kindly review this commit for building this package on different build systems having different versions of Boost.